### PR TITLE
feat: add missing transfer event

### DIFF
--- a/src/SavingsDai.sol
+++ b/src/SavingsDai.sol
@@ -235,6 +235,7 @@ contract SavingsDai {
         }
 
         emit Deposit(msg.sender, receiver, assets, shares);
+        emit Transfer(address(0), receiver, shares);
     }
 
     function _burn(uint256 assets, uint256 shares, address receiver, address owner) internal {
@@ -261,6 +262,7 @@ contract SavingsDai {
         daiJoin.exit(receiver, assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        emit Transfer(owner, address(0), shares);
     }
 
     // --- ERC-4626 ---


### PR DESCRIPTION
this fixes `balanceOf` updates by `mint/deposit/burn/withdraw` not being picked up by explorers and wallets.

emitting `Transfer` from/to zero address is both a recommended part of [eip-20](https://eips.ethereum.org/EIPS/eip-20) and a widely accepted convention.

> A token contract which creates new tokens SHOULD trigger a Transfer event with the _from address set to 0x0 when tokens are created.